### PR TITLE
feat: allow client to be configure with urls instead of metadata

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   check:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         toolchain:
@@ -69,7 +69,7 @@ jobs:
 
   examples:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
 
   init:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{steps.version.outputs.version}}
       prerelease: ${{steps.state.outputs.prerelease}}
@@ -46,7 +46,7 @@ jobs:
   # publish directly after CI check
   publish:
     needs: [ init, ci ]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
 
       - name: Checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-oauth2"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Jens Reimann <jreimann@redhat.com>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,14 @@
 name = "yew-oauth2"
 version = "0.11.0"
 authors = ["Jens Reimann <jreimann@redhat.com>"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "OAuth2 components for Yew"
 repository = "https://github.com/ctron/yew-oauth2"
 categories = ["wasm", "web-programming", "gui"]
 keywords = ["yew", "oauth2", "oidc", "web", "html"]
 readme = "README.md"
-rust-version = "1.70"
+rust-version = "1.85"
 
 [dependencies]
 async-trait = "0.1"
@@ -32,7 +32,7 @@ web-sys = { version = "0.3", features = [
     "Window",
 ] }
 
-openidconnect = { version = "4.0.1", optional = true , features = ["timing-resistant-secret-traits"]}
+openidconnect = { version = "4.0.1", optional = true, features = ["timing-resistant-secret-traits"] }
 yew-nested-router = { version = "0.7.0", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ web-sys = { version = "0.3", features = [
     "Window",
 ] }
 
-openidconnect = { version = "4.0.1", optional = true }
+openidconnect = { version = "4.0.1", optional = true , features = ["timing-resistant-secret-traits"]}
 yew-nested-router = { version = "0.7.0", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ gloo-utils = "0.2"
 js-sys = "0.3"
 log = "0.4"
 num-traits = "0.2"
-oauth2 = "4"
-reqwest = "0.11"
+oauth2 = "5.0.0"
+reqwest = "0.12.22"
 serde = { version = "1", features = ["derive"] }
 time = { version = "0.3", features = ["wasm-bindgen"] }
 tokio = { version = "1", features = ["sync"] }
@@ -32,7 +32,7 @@ web-sys = { version = "0.3", features = [
     "Window",
 ] }
 
-openidconnect = { version = "3.0", optional = true }
+openidconnect = { version = "4.0.1", optional = true }
 yew-nested-router = { version = "0.7.0", optional = true }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 Add to your `Cargo.toml`:
 
 ```toml
-yew-oauth2 = "0.11"
+yew-oauth2 = "0.12"
 ```
 
 By default, the `yew-nested-router` integration for [`yew-nested-router`](https://github.com/ctron/yew-nested-router) is
 disabled. You can enable it using:
 
 ```toml
-yew-oauth2 = { version = "0.10", features = ["yew-nested-router"] }
+yew-oauth2 = { version = "0.12", features = ["yew-nested-router"] }
 ```
 
 ## OpenID Connect

--- a/src/agent/client/mod.rs
+++ b/src/agent/client/mod.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use js_sys::Date;
 use num_traits::ToPrimitive;
 use reqwest::Url;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::fmt::Debug;
 use std::time::Duration;
 

--- a/src/agent/client/oauth2.rs
+++ b/src/agent/client/oauth2.rs
@@ -33,6 +33,7 @@ impl OAuth2Client {
     fn make_authenticated(result: BasicTokenResponse) -> OAuth2Context {
         OAuth2Context::Authenticated(Authentication {
             access_token: result.access_token().secret().to_string(),
+            id_token: None,
             refresh_token: result.refresh_token().map(|t| t.secret().to_string()),
             expires: expires(result.expires_in()),
             #[cfg(feature = "openid")]

--- a/src/agent/client/oauth2.rs
+++ b/src/agent/client/oauth2.rs
@@ -1,17 +1,17 @@
 use crate::{
     agent::{
-        client::{expires, Client, LoginContext},
         InnerConfig, OAuth2Error,
+        client::{Client, LoginContext, expires},
     },
     config::oauth2,
     context::{Authentication, OAuth2Context},
 };
 use ::oauth2::{
+    AuthUrl, AuthorizationCode, ClientId, CsrfToken, EndpointNotSet, EndpointSet,
+    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RefreshToken, Scope, TokenResponse, TokenUrl,
     basic::{BasicClient, BasicTokenResponse},
     reqwest,
     url::Url,
-    AuthUrl, AuthorizationCode, ClientId, CsrfToken, EndpointNotSet, EndpointSet,
-    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RefreshToken, Scope, TokenResponse, TokenUrl,
 };
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};

--- a/src/agent/client/openid.rs
+++ b/src/agent/client/openid.rs
@@ -103,15 +103,10 @@ impl Client for OpenIdClient {
             post_logout_redirect_name,
             additional_trusted_audiences,
             require_issuer_match,
-            follow_client_redirects,
         } = config;
 
-        let redirect_policy = match follow_client_redirects {
-            true => openidconnect::reqwest::redirect::Policy::limited(1),
-            false => openidconnect::reqwest::redirect::Policy::none(),
-        };
         let http_client = openidconnect::reqwest::ClientBuilder::new()
-            .redirect(redirect_policy)
+            // we can't control redirect here, as we're using WASM request, which basically is the browser
             .build()
             .map_err(|err| {
                 OAuth2Error::Configuration(format!("Failed to build HTTP client: {err}"))

--- a/src/agent/client/openid.rs
+++ b/src/agent/client/openid.rs
@@ -46,6 +46,8 @@ pub struct OpenIdClient {
     post_logout_redirect_name: Option<String>,
     /// Additional audiences of the ID token which are considered trustworthy
     additional_trusted_audiences: Vec<String>,
+    /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
+    pub require_issuer_match: bool,
 }
 
 /// Additional metadata read from the discovery endpoint
@@ -93,6 +95,7 @@ impl Client for OpenIdClient {
             after_logout_url,
             post_logout_redirect_name,
             additional_trusted_audiences,
+            require_issuer_match,
         } = config;
 
         let issuer = IssuerUrl::new(issuer_url)
@@ -120,6 +123,7 @@ impl Client for OpenIdClient {
             after_logout_url,
             post_logout_redirect_name,
             additional_trusted_audiences,
+            require_issuer_match,
         })
     }
 
@@ -194,6 +198,7 @@ impl Client for OpenIdClient {
                     &self
                         .client
                         .id_token_verifier()
+                        .require_issuer_match(self.require_issuer_match)
                         .set_other_audience_verifier_fn(|aud| {
                             self.additional_trusted_audiences.contains(aud)
                         }),

--- a/src/agent/client/openid.rs
+++ b/src/agent/client/openid.rs
@@ -8,11 +8,12 @@ use crate::{
 };
 use async_trait::async_trait;
 use gloo_utils::window;
-use oauth2::TokenResponse;
+use oauth2::TokenResponse as _;
 use openidconnect::{
-    AuthorizationCode, ClientId, CsrfToken, EmptyAdditionalClaims, EndpointMaybeSet,
-    EndpointNotSet, EndpointSet, IdTokenClaims, IssuerUrl, Nonce, PkceCodeChallenge,
-    PkceCodeVerifier, ProviderMetadata, RedirectUrl, RefreshToken, Scope,
+    AuthUrl, AuthorizationCode, ClientId, CsrfToken, EmptyAdditionalClaims, EndpointNotSet,
+    EndpointSet, IdTokenClaims, IssuerUrl, JsonWebKeySet, JsonWebKeySetUrl, Nonce,
+    PkceCodeChallenge, PkceCodeVerifier, ProviderMetadata, RedirectUrl, RefreshToken, Scope,
+    TokenResponse, TokenUrl, UserInfoUrl,
     core::{
         CoreAuthDisplay, CoreAuthenticationFlow, CoreClaimName, CoreClaimType, CoreClient,
         CoreClientAuthMethod, CoreGenderClaim, CoreGrantType, CoreJsonWebKey,
@@ -81,7 +82,7 @@ pub type ExtendedClient = CoreClient<
     EndpointNotSet,
     EndpointNotSet,
     EndpointSet,
-    EndpointMaybeSet,
+    EndpointSet,
 >;
 
 #[async_trait(? Send)]
@@ -95,63 +96,21 @@ impl Client for OpenIdClient {
     );
 
     async fn from_config(config: Self::Configuration) -> Result<Self, OAuth2Error> {
-        let openid::Config {
-            client_id,
-            issuer_url,
-            end_session_url,
-            after_logout_url,
-            post_logout_redirect_name,
-            additional_trusted_audiences,
-            require_issuer_match,
-        } = config;
-
-        let http_client = openidconnect::reqwest::ClientBuilder::new()
-            // we can't control redirect here, as we're using WASM request, which basically is the browser
-            .build()
-            .map_err(|err| {
-                OAuth2Error::Configuration(format!("Failed to build HTTP client: {err}"))
-            })?;
-
-        let issuer = IssuerUrl::new(issuer_url)
-            .map_err(|err| OAuth2Error::Configuration(format!("invalid issuer URL: {err}")))?;
-
-        let metadata = ExtendedProviderMetadata::discover_async(issuer, &http_client)
-            .await
-            .map_err(|err| {
-                OAuth2Error::Configuration(format!("Failed to discover client: {err}"))
-            })?;
-
-        // Extract the URIs we MUST have
-        let auth_uri = metadata.authorization_endpoint().clone();
-
-        let token_uri = metadata
-            .token_endpoint()
-            .ok_or_else(|| {
-                OAuth2Error::Configuration("Provider missing required token endpoint".into())
-            })?
-            .clone();
-
-        let end_session_url = end_session_url
-            .map(|url| Url::parse(&url))
-            .transpose()
-            .map_err(|err| {
-                OAuth2Error::Configuration(format!("Unable to parse end_session_url: {err}"))
-            })?
-            .or_else(|| metadata.additional_metadata().end_session_endpoint.clone());
-
-        let client = CoreClient::from_provider_metadata(metadata, ClientId::new(client_id), None)
-            .set_auth_uri(auth_uri)
-            .set_token_uri(token_uri);
-
-        Ok(Self {
-            http_client,
-            client,
-            end_session_url,
-            after_logout_url,
-            post_logout_redirect_name,
-            additional_trusted_audiences,
-            require_issuer_match,
-        })
+        match (
+            &config.jwks_url,
+            &config.auth_url,
+            &config.token_url,
+            &config.user_info_url,
+        ) {
+            (Some(_), Some(_), Some(_), Some(_)) => {
+                log::debug!("Constructing client from feeded urls");
+                Self::from_urls(config).await
+            }
+            _ => {
+                log::debug!("Constructing client from provider metadata");
+                Self::from_metadata(config).await
+            }
+        }
     }
 
     fn set_redirect_uri(mut self, url: Url) -> Self {
@@ -239,6 +198,7 @@ impl Client for OpenIdClient {
         Ok((
             OAuth2Context::Authenticated(Authentication {
                 access_token: result.access_token().secret().to_string(),
+                id_token: result.id_token().map(|t| t.to_string()),
                 refresh_token: result.refresh_token().map(|t| t.secret().to_string()),
                 expires: expires(result.expires_in()),
                 claims: Some(claims.clone()),
@@ -264,6 +224,7 @@ impl Client for OpenIdClient {
         Ok((
             OAuth2Context::Authenticated(Authentication {
                 access_token: result.access_token().secret().to_string(),
+                id_token: result.id_token().map(|t| t.to_string()),
                 refresh_token: result.refresh_token().map(|t| t.secret().to_string()),
                 expires: expires(result.expires_in()),
                 claims: Some(session_state.1.clone()),
@@ -322,5 +283,167 @@ impl OpenIdClient {
         } else {
             window().location().href().ok()
         }
+    }
+    async fn from_metadata(config: openid::Config) -> Result<Self, OAuth2Error> {
+        let openid::Config {
+            client_id,
+            issuer_url,
+            end_session_url,
+            after_logout_url,
+            post_logout_redirect_name,
+            additional_trusted_audiences,
+            require_issuer_match,
+            ..
+        } = config;
+
+        let http_client = openidconnect::reqwest::ClientBuilder::new()
+            // we can't control redirect here, as we're using WASM request, which basically is the browser
+            .build()
+            .map_err(|err| {
+                OAuth2Error::Configuration(format!("Failed to build HTTP client: {err}"))
+            })?;
+
+        let issuer = IssuerUrl::new(issuer_url)
+            .map_err(|err| OAuth2Error::Configuration(format!("invalid issuer URL: {err}")))?;
+
+        let metadata = ExtendedProviderMetadata::discover_async(issuer, &http_client)
+            .await
+            .map_err(|err| {
+                OAuth2Error::Configuration(format!("Failed to discover client: {err}"))
+            })?;
+
+        // Extract the URIs we MUST have
+        let auth_uri = metadata.authorization_endpoint().clone();
+
+        let token_uri = metadata
+            .token_endpoint()
+            .ok_or_else(|| {
+                OAuth2Error::Configuration("Provider missing required token endpoint".into())
+            })?
+            .clone();
+
+        let user_info_uri = metadata
+            .userinfo_endpoint()
+            .ok_or_else(|| {
+                OAuth2Error::Configuration("Provider missing required auth info endpoint".into())
+            })?
+            .clone();
+
+        let end_session_url = end_session_url
+            .map(|url| Url::parse(&url))
+            .transpose()
+            .map_err(|err| {
+                OAuth2Error::Configuration(format!("Unable to parse end_session_url: {err}"))
+            })?
+            .or_else(|| metadata.additional_metadata().end_session_endpoint.clone());
+
+        let client = CoreClient::from_provider_metadata(metadata, ClientId::new(client_id), None)
+            .set_auth_uri(auth_uri)
+            .set_token_uri(token_uri)
+            .set_user_info_url(user_info_uri);
+        Ok(Self {
+            http_client,
+            client,
+            end_session_url,
+            after_logout_url,
+            post_logout_redirect_name,
+            additional_trusted_audiences,
+            require_issuer_match,
+        })
+    }
+
+    async fn from_urls(config: openid::Config) -> Result<Self, OAuth2Error> {
+        let openid::Config {
+            client_id,
+            issuer_url,
+            end_session_url,
+            after_logout_url,
+            post_logout_redirect_name,
+            additional_trusted_audiences,
+            require_issuer_match,
+            jwks_url,
+            auth_url,
+            token_url,
+            user_info_url,
+        } = config;
+
+        let http_client = openidconnect::reqwest::ClientBuilder::new()
+            // Following redirects opens the client up to SSRF vulnerabilities.
+            // .redirect(openidconnect::reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|err| {
+                OAuth2Error::Configuration(format!("Failed to build HTTP client: {err}"))
+            })?;
+
+        let issuer = IssuerUrl::new(issuer_url)
+            .map_err(|err| OAuth2Error::Configuration(format!("invalid issuer URL: {err}")))?;
+
+        let auth_uri = auth_url
+            .map(AuthUrl::new)
+            .transpose()
+            .map_err(|err| OAuth2Error::Configuration(format!("invalid auth URL: {err}")))?
+            .ok_or_else(|| {
+                OAuth2Error::Configuration(
+                    "Cannot build Auth2 client without metadata: missing auth url".to_string(),
+                )
+            })?;
+
+        let token_uri = token_url
+            .map(TokenUrl::new)
+            .transpose()
+            .map_err(|err| OAuth2Error::Configuration(format!("invalid token URL: {err}")))?
+            .ok_or_else(|| {
+                OAuth2Error::Configuration(
+                    "Cannot build Auth2 client without metadata: missing token url".to_string(),
+                )
+            })?;
+
+        let jwks_uri = jwks_url
+            .map(JsonWebKeySetUrl::new)
+            .transpose()
+            .map_err(|err| OAuth2Error::Configuration(format!("invalid jwks URL: {err}")))?
+            .ok_or_else(|| {
+                OAuth2Error::Configuration(
+                    "Cannot build Auth2 client without metadata: missing jwks url".to_string(),
+                )
+            })?;
+
+        let jwks = JsonWebKeySet::fetch_async(&jwks_uri, &http_client)
+            .await
+            .map_err(|err| OAuth2Error::Configuration(format!("Could not fetch jwks: {err}")))?;
+
+        let user_info_url = user_info_url
+            .map(UserInfoUrl::new)
+            .transpose()
+            .map_err(|err| {
+                OAuth2Error::Configuration(format!("Unable to parse user_info_url: {err}"))
+            })?
+            .ok_or_else(|| {
+                OAuth2Error::Configuration(
+                    "Cannot build Auth2 client without metadata: missing user_info url".to_string(),
+                )
+            })?;
+
+        let end_session_url = end_session_url
+            .map(|url| Url::parse(&url))
+            .transpose()
+            .map_err(|err| {
+                OAuth2Error::Configuration(format!("Unable to parse end_session_url: {err}"))
+            })?;
+
+        let client = CoreClient::new(ClientId::new(client_id), issuer, jwks)
+            .set_auth_uri(auth_uri)
+            .set_token_uri(token_uri)
+            .set_user_info_url(user_info_url);
+
+        Ok(Self {
+            http_client,
+            client,
+            end_session_url,
+            after_logout_url,
+            post_logout_redirect_name,
+            additional_trusted_audiences,
+            require_issuer_match,
+        })
     }
 }

--- a/src/agent/client/openid.rs
+++ b/src/agent/client/openid.rs
@@ -103,11 +103,15 @@ impl Client for OpenIdClient {
             post_logout_redirect_name,
             additional_trusted_audiences,
             require_issuer_match,
+            follow_client_redirects,
         } = config;
 
+        let redirect_policy = match follow_client_redirects {
+            true => openidconnect::reqwest::redirect::Policy::limited(1),
+            false => openidconnect::reqwest::redirect::Policy::none(),
+        };
         let http_client = openidconnect::reqwest::ClientBuilder::new()
-            // Following redirects opens the client up to SSRF vulnerabilities.
-            // .redirect(openidconnect::reqwest::redirect::Policy::none())
+            .redirect(redirect_policy)
             .build()
             .map_err(|err| {
                 OAuth2Error::Configuration(format!("Failed to build HTTP client: {err}"))

--- a/src/agent/client/openid.rs
+++ b/src/agent/client/openid.rs
@@ -1,7 +1,7 @@
 use crate::{
     agent::{
-        client::{expires, Client, LoginContext},
         InnerConfig, LogoutOptions, OAuth2Error,
+        client::{Client, LoginContext, expires},
     },
     config::openid,
     context::{Authentication, OAuth2Context},
@@ -10,15 +10,15 @@ use async_trait::async_trait;
 use gloo_utils::window;
 use oauth2::TokenResponse;
 use openidconnect::{
+    AuthorizationCode, ClientId, CsrfToken, EmptyAdditionalClaims, EndpointMaybeSet,
+    EndpointNotSet, EndpointSet, IdTokenClaims, IssuerUrl, Nonce, PkceCodeChallenge,
+    PkceCodeVerifier, ProviderMetadata, RedirectUrl, RefreshToken, Scope,
     core::{
         CoreAuthDisplay, CoreAuthenticationFlow, CoreClaimName, CoreClaimType, CoreClient,
         CoreClientAuthMethod, CoreGenderClaim, CoreGrantType, CoreJsonWebKey,
         CoreJweContentEncryptionAlgorithm, CoreJweKeyManagementAlgorithm, CoreResponseMode,
         CoreResponseType, CoreSubjectIdentifierType, CoreTokenResponse,
     },
-    AuthorizationCode, ClientId, CsrfToken, EmptyAdditionalClaims, EndpointMaybeSet,
-    EndpointNotSet, EndpointSet, IdTokenClaims, IssuerUrl, Nonce, PkceCodeChallenge,
-    PkceCodeVerifier, ProviderMetadata, RedirectUrl, RefreshToken, Scope,
 };
 use reqwest::Url;
 use serde::{Deserialize, Serialize};

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -307,7 +307,7 @@ where
             if diff > 0f64 {
                 // while the API says millis is u32, internally it is i32
                 let millis = (diff * 1000f64).to_i32().unwrap_or(i32::MAX);
-                log::debug!("Starting timeout for: {}ms", millis);
+                log::debug!("Starting timeout for: {millis}ms",);
                 self.timeout = Some(Timeout::new(millis as u32, move || {
                     let _ = tx.try_send(Msg::Refresh);
                 }));
@@ -409,7 +409,7 @@ where
             return Ok(false);
         };
 
-        log::debug!("Found state: {:?}", state);
+        log::debug!("Found state: {state:?}",);
 
         if let Some(error) = state.error {
             log::info!("Login error from server: {error}");

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -23,7 +23,7 @@ use num_traits::cast::ToPrimitive;
 use reqwest::Url;
 use state::*;
 use std::{cmp::min, collections::HashMap, fmt::Debug, time::Duration};
-use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::mpsc::{Receiver, Sender, channel};
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::spawn_local;
 use yew::Callback;
@@ -429,7 +429,7 @@ where
                 None => {
                     return Err(OAuth2Error::LoginResult(
                         "Missing state from server".to_string(),
-                    ))
+                    ));
                 }
                 Some(state) => {
                     let stored_state = get_from_store(STORAGE_KEY_CSRF_TOKEN)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,8 +34,6 @@ pub mod openid {
         pub additional_trusted_audiences: Vec<String>,
         /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
         pub require_issuer_match: bool,
-        /// Allow following redirect (Be careful it opens the client up to SSRF vulnerabilities)
-        pub follow_client_redirects: bool,
     }
 
     impl Config {
@@ -50,7 +48,6 @@ pub mod openid {
                 post_logout_redirect_name: None,
                 additional_trusted_audiences: vec![],
                 require_issuer_match: true,
-                follow_client_redirects: false,
             }
         }
 
@@ -110,12 +107,6 @@ pub mod openid {
         /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
         pub fn with_require_issuer_match(mut self, require_issuer_match: bool) -> Self {
             self.require_issuer_match = require_issuer_match;
-            self
-        }
-
-        /// Allow following redirect (Be careful it opens the client up to SSRF vulnerabilities)
-        pub fn with_follow_client_redirects(mut self, follow_redirect: bool) -> Self {
-            self.follow_client_redirects = follow_redirect;
             self
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,8 @@ pub mod openid {
         ///
         /// Those audiences are allowed in addition to the client ID.
         pub additional_trusted_audiences: Vec<String>,
+        /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
+        pub require_issuer_match: bool,
     }
 
     impl Config {
@@ -45,6 +47,7 @@ pub mod openid {
                 after_logout_url: None,
                 post_logout_redirect_name: None,
                 additional_trusted_audiences: vec![],
+                require_issuer_match: true,
             }
         }
 
@@ -98,6 +101,12 @@ pub mod openid {
         ) -> Self {
             self.additional_trusted_audiences
                 .push(additional_trusted_audience.into());
+            self
+        }
+
+        /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
+        pub fn with_require_issuer_match(mut self, require_issuer_match: bool) -> Self {
+            self.require_issuer_match = require_issuer_match;
             self
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,15 @@ pub mod openid {
         pub client_id: String,
         /// The OpenID connect issuer URL.
         pub issuer_url: String,
+        /// If the following urls are set, the client will be built from them
+        /// The OpenID connect auth URL.
+        pub auth_url: Option<String>,
+        /// The OpenID token auth URL.
+        pub token_url: Option<String>,
+        /// The OpenID user info auth URL.
+        pub user_info_url: Option<String>,
+        /// The OpenID jwks url.
+        pub jwks_url: Option<String>,
         /// An override for the end session URL.
         pub end_session_url: Option<String>,
         /// The URL to navigate to after the logout has been completed.
@@ -42,6 +51,11 @@ pub mod openid {
             Self {
                 client_id: client_id.into(),
                 issuer_url: issuer_url.into(),
+
+                auth_url: None,
+                token_url: None,
+                user_info_url: None,
+                jwks_url: None,
 
                 end_session_url: None,
                 after_logout_url: None,
@@ -107,6 +121,28 @@ pub mod openid {
         /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
         pub fn with_require_issuer_match(mut self, require_issuer_match: bool) -> Self {
             self.require_issuer_match = require_issuer_match;
+            self
+        }
+
+        /// Set the provider auth url, skip metadata
+        pub fn with_auth_url(mut self, auth_url: impl Into<String>) -> Self {
+            self.auth_url = Some(auth_url.into());
+            self
+        }
+
+        /// Set the provider token url, skip metadata
+        pub fn with_token_url(mut self, token_url: impl Into<String>) -> Self {
+            self.token_url = Some(token_url.into());
+            self
+        }
+        /// Set the provider user_info url, skip metadata
+        pub fn with_user_info_url(mut self, user_info_url: impl Into<String>) -> Self {
+            self.user_info_url = Some(user_info_url.into());
+            self
+        }
+        /// Set the provider jwks url, skip metadata
+        pub fn with_jwks_url(mut self, jwks_url: impl Into<String>) -> Self {
+            self.jwks_url = Some(jwks_url.into());
             self
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,8 @@ pub mod openid {
         pub additional_trusted_audiences: Vec<String>,
         /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
         pub require_issuer_match: bool,
+        /// Allow following redirect (Be careful it opens the client up to SSRF vulnerabilities)
+        pub follow_client_redirects: bool,
     }
 
     impl Config {
@@ -48,6 +50,7 @@ pub mod openid {
                 post_logout_redirect_name: None,
                 additional_trusted_audiences: vec![],
                 require_issuer_match: true,
+                follow_client_redirects: false,
             }
         }
 
@@ -107,6 +110,12 @@ pub mod openid {
         /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
         pub fn with_require_issuer_match(mut self, require_issuer_match: bool) -> Self {
             self.require_issuer_match = require_issuer_match;
+            self
+        }
+
+        /// Allow following redirect (Be careful it opens the client up to SSRF vulnerabilities)
+        pub fn with_follow_client_redirects(mut self, follow_redirect: bool) -> Self {
+            self.follow_client_redirects = follow_redirect;
             self
         }
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -18,6 +18,8 @@ pub type Claims = openidconnect::IdTokenClaims<
 pub struct Authentication {
     /// The access token
     pub access_token: String,
+    /// The id token
+    pub id_token: Option<String>,
     /// An optional refresh token
     pub refresh_token: Option<String>,
     /// OpenID claims
@@ -59,6 +61,12 @@ impl OAuth2Context {
     /// Get the access token, if the context is [`OAuth2Context::Authenticated`]
     pub fn access_token(&self) -> Option<&str> {
         self.authentication().map(|auth| auth.access_token.as_str())
+    }
+
+    /// Get the id token, if the context is [`OAuth2Context::Authenticated`]
+    pub fn id_token(&self) -> Option<&str> {
+        self.authentication()
+            .and_then(|auth| auth.id_token.as_deref())
     }
 
     /// Get the claims, if the context is [`OAuth2Context::Authenticated`]

--- a/yew-oauth2-example/Cargo.toml
+++ b/yew-oauth2-example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yew-oauth2-example"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 yew-oauth2 = { path = ".." }

--- a/yew-oauth2-example/Cargo.toml
+++ b/yew-oauth2-example/Cargo.toml
@@ -16,7 +16,7 @@ wasm-logger = "0.2"
 yew = { version = "0.21.0", features = ["csr"] }
 yew-nested-router = "0.7.0"
 
-openidconnect = { version = "3.0", optional = true }
+openidconnect = { version = "4", optional = true }
 
 [features]
 default = ["openid"]

--- a/yew-oauth2-redirect-example/Cargo.toml
+++ b/yew-oauth2-redirect-example/Cargo.toml
@@ -16,7 +16,7 @@ wasm-logger = "0.2"
 yew = { version = "0.21.0", features = ["csr"] }
 yew-nested-router = "0.7.0"
 
-openidconnect = { version = "3.0", optional = true }
+openidconnect = { version = "4", optional = true }
 
 [features]
 default = ["openid"]

--- a/yew-oauth2-redirect-example/Cargo.toml
+++ b/yew-oauth2-redirect-example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yew-oauth2-redirect-example"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 yew-oauth2 = { path = "..", features = ["yew-nested-router"] }


### PR DESCRIPTION
In some cases we cannot rely on the auth provider autodiscovery